### PR TITLE
WIP: for writing to fixed-width txt file

### DIFF
--- a/utils/ITCHbin.py
+++ b/utils/ITCHbin.py
@@ -6,6 +6,7 @@ It assumes their squirrelly binary message format.'''
 
 import struct
 import gzip
+import csv
 
 
 class ITCHv5:
@@ -111,6 +112,16 @@ class ITCHv5:
         '''
         return self.fname[self.fname.rfind('/')+1 : self.fname.find('-')]
 
+    def to_fixed_width(self):
+        '''Output the records to a fixed-width text for each message type'''
+        base = self.base_fname()
+        for rec in self.records():
+            rec = [self.to_string(r) for r in rec]
+            msg_type = rec[0]
+            with open(base+'_'+rec[0]+'.txt', 'a') as outfile:
+                writer = csv.writer(outfile)
+                writer.writerow([' '.join(rec[3:])])
+
 
 if __name__ == '__main__':
     from sys import argv, exit
@@ -120,4 +131,5 @@ if __name__ == '__main__':
         print('Usage: ITCHbin.py <ITCH v5.0 file>')
         exit(1)
 
-    itch.print_records()
+    # itch.print_records()
+    itch.to_fixed_width()

--- a/utils/ITCHbin.py
+++ b/utils/ITCHbin.py
@@ -105,6 +105,13 @@ class ITCHv5:
             # 6-byte integer
             print(','.join(self.to_string(r) for r in rec))
 
+    def base_fname(self):
+        '''Get the file name, excluding any filepath chars,
+        file extensions, and version numbers
+        '''
+        return self.fname[self.fname.rfind('/')+1 : self.fname.find('-')]
+
+
 if __name__ == '__main__':
     from sys import argv, exit
     try:


### PR DESCRIPTION
This outputs a fixed-width file for each message type. Example filenames: `S030315_H.txt`, `S030315_L.txt`, and `S030315_R.txt`.

This uses `csv.writer()`. In 2m47s, 146,891 records were written. I'm not sure that this is fast enough, but I wanted to push some working code and then think about how to improve it.

One thought I had earlier, which I mentioned in my email, was to create a DataFrame&mdash;I could also create a `np.ndarray()`&mdash;first and use something like the `.to_csv()` method to output. The idea is to reduce the number of times the disk is accessed. Right now, it's once per record :-1:

In any case, feedback is requested, @davclark. Thanks!
